### PR TITLE
Fixed com.netflix.astyanax.connectionpool.exceptions.PoolTimeoutException

### DIFF
--- a/src/main/java/com/netflix/jmeter/connections/a6x/AstyanaxConnection.java
+++ b/src/main/java/com/netflix/jmeter/connections/a6x/AstyanaxConnection.java
@@ -78,6 +78,7 @@ public class AstyanaxConnection extends Connection
                 String maxConnection = com.netflix.jmeter.properties.Properties.instance.cassandra.getMaxConnsPerHost();
                 ConnectionPoolConfigurationImpl poolConfig = new ConnectionPoolConfigurationImpl(getClusterName()).setPort(port);
                 poolConfig.setMaxConnsPerHost(Integer.parseInt(maxConnection));
+                poolConfig.setMaxBlockedThreadsPerHost(Integer.parseInt(maxConnection));
                 poolConfig.setSeeds(StringUtils.join(endpoints, ":" + port + ","));
                 poolConfig.setLatencyScoreStrategy(latencyScoreStrategy);
                 
@@ -91,7 +92,7 @@ public class AstyanaxConnection extends Connection
                 builder.withConnectionPoolConfiguration(poolConfig);
                 builder.withConnectionPoolMonitor(connectionPoolMonitor);
                 builder.withConnectionPoolMonitor(new CountingConnectionPoolMonitor());
-
+                
                 AstyanaxContext<Keyspace> context = builder.buildKeyspace(ThriftFamilyFactory.getInstance());
                 context.start();
                 keyspace = context.getEntity();


### PR DESCRIPTION
Previously, a com.netflix.astyanax.connectionpool.exceptions.PoolTimeoutException was occurring when running a test with a number of concurrent threads higher than 2.
This was due to MaxBlockedThreadsPerHost not set into com.netflix.jmeter.connections.a6x.AstyanaxConnection.
