### PR TITLE
CassJMeter-1: assert was indeed wrong.

### DIFF
--- a/src/main/java/com/netflix/jmeter/properties/Properties.java
+++ b/src/main/java/com/netflix/jmeter/properties/Properties.java
@@ -10,7 +10,7 @@ import com.netflix.jmeter.connections.a6x.AstyanaxConnection;
 
 public class Properties
 {
-    private static final Logger logger = LoggerFactory.getLogger(AstyanaxConnection.class);
+    private static final Logger logger = LoggerFactory.getLogger(Properties.class);
     public static final Properties instance = new Properties();
     public CassandraProperties cassandra;
     public FatclientProperties fatclient;

--- a/src/main/java/com/netflix/jmeter/sampler/Connection.java
+++ b/src/main/java/com/netflix/jmeter/sampler/Connection.java
@@ -49,7 +49,7 @@ public abstract class Connection
             temp.add(hp[0]);
             port = Integer.parseInt(hp[1]);
         }
-        assert temp.size() == 0;
+        assert temp.size() > 0;
         endpoints = temp;
     }
 


### PR DESCRIPTION
however, I don't think most folks (if anyone) would have run into the assert failing as you would need to modify the <jmeter>/bin/jmeter.sh and pass '-ea' to the java command. hence, this probably didn't fail much in the real world :). fixing because it's the right thing to do.
