### PR TITLE
Added JMX port support to the casstat script.

### DIFF
--- a/bin/casstat
+++ b/bin/casstat
@@ -299,7 +299,7 @@ sample_count=100000
 port=7501
 
 
-while getopts “hexprstjlm:i:k:c:n:d:o:f:” OPTION
+while getopts “hexprstjl:m:i:k:c:n:d:o:f:” OPTION
 do
      case $OPTION in
          h)


### PR DESCRIPTION
This script had a hard-coded jmx port of 7501.  I set the script up to default to this port, but also accept a jmx port variable to allow the user to set whatever port they wanted.
