### PR TITLE
Latency should be less than elapsed time

### DIFF
--- a/src/main/java/com/netflix/jmeter/sampler/AbstractSampler.java
+++ b/src/main/java/com/netflix/jmeter/sampler/AbstractSampler.java
@@ -217,8 +217,8 @@ public abstract class AbstractSampler extends org.apache.jmeter.samplers.Abstrac
         finally
         {
             sr.setResponseData(message);
-            sr.sampleEnd();
             long latency = System.currentTimeMillis() - start;
+            sr.sampleEnd();
             sr.setLatency(latency);
             /*
              * A6x reports the latency via thrift. the following logic will


### PR DESCRIPTION
I have tests where latency higher than elapsed time:)
