### PR TITLE
updating to work with jmeter 2.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
 	<groupId>com.netflix</groupId>
 	<artifactId>CassJMeter</artifactId>
 	<packaging>jar</packaging>
-	<version>0.1-SNAPSHOT</version>
+	<version>0.2-SNAPSHOT</version>
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.jmeter</groupId>
 			<artifactId>ApacheJMeter_core</artifactId>
-			<version>2.6</version>
+			<version>2.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hectorclient</groupId>
@@ -25,6 +25,12 @@
 			<groupId>com.netflix.astyanax</groupId>
 			<artifactId>astyanax</artifactId>
 			<version>1.56.25</version>
+		</dependency>
+		<!-- setting to the same version as astyanax as hector pulls in r09 -->
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>11.0.1</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/src/main/java/com/netflix/jmeter/report/ServoSummariser.java
+++ b/src/main/java/com/netflix/jmeter/report/ServoSummariser.java
@@ -7,7 +7,6 @@ import com.netflix.servo.monitor.Monitors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.netflix.servo.DefaultMonitorRegistry;
 import com.netflix.servo.annotations.DataSourceType;
 import com.netflix.servo.annotations.Monitor;
 import com.netflix.servo.publish.BasicMetricFilter;


### PR DESCRIPTION
forcing guava 11.0 as hector tries to pull in r09, whuch causes astyanax to fail.
